### PR TITLE
Env settings and users

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.env.local

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,9 +5,6 @@ ARG branch=master
 
 ADD run.sh /tmp/run.sh
 
-ADD clean.sh /tmp/clean.sh
-RUN bash /tmp/clean.sh
-
 RUN pip install -e git+https://github.com/${user}/jupyterhub-singleuser-profiles.git@${branch}#egg=jupyterhub_singleuser_profiles
 
 RUN bash /tmp/run.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,9 @@ ARG branch=master
 
 ADD run.sh /tmp/run.sh
 
+ADD clean.sh /tmp/clean.sh
+RUN bash /tmp/clean.sh
+
 RUN pip install -e git+https://github.com/${user}/jupyterhub-singleuser-profiles.git@${branch}#egg=jupyterhub_singleuser_profiles
 
 RUN bash /tmp/run.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/odh-jupyterhub/jupyterhub-img:v0.3.3
+FROM quay.io/odh-jupyterhub/jupyterhub-img:v0.3.4
 
 ARG user=vpavlin
 ARG branch=master

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ NAMESPACE ?= $(USER)-odh
 OPERATOR_NAME ?= odh-operator
 OPERATOR_NAMESPACE ?= odh-ods-operator
 GIT_REF ?= master
-REMOTE_CMD ?= podman
+LOCAL_CMD ?= podman
 
 IMAGE_NAME=jupyterhub-img
 IMAGE_TAG ?= test-jsp
@@ -47,13 +47,13 @@ check-env:
 	echo user: $(GIT_REF)
 
 build-local:
-	$(REMOTE_CMD) build . --build-arg user=$(GIT_USER) --build-arg branch=$(GIT_REF) --build-arg repo=${GIT_REPO} --no-cache -t $(IMAGE) -f ${DOCKERFILE}
+	$(LOCAL_CMD) build . --build-arg user=$(GIT_USER) --build-arg branch=$(GIT_REF) --build-arg repo=${GIT_REPO} --no-cache -t $(IMAGE) -f ${DOCKERFILE}
 
 tag:
-	$(REMOTE_CMD) tag $(IMAGE) $(TARGET)
+	$(LOCAL_CMD) tag $(IMAGE) $(TARGET)
 
 push:
-	$(REMOTE_CMD) push $(TARGET)
+	$(LOCAL_CMD) push $(TARGET)
 
 import:
 	oc import-image -n $(NAMESPACE) jupyterhub-img

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ QUAY_REPO ?= $(USER)
 GIT_USER ?= $(USER)
 NAMESPACE ?= $(USER)-odh
 OPERATOR_NAME ?= odh-operator
-OPERATOR_NAMESPACE ?= $(USER)-ods-operator
+OPERATOR_NAMESPACE ?= odh-ods-operator
 GIT_REF ?= master
 REMOTE_CMD ?= podman
 
@@ -23,6 +23,17 @@ TARGET=quay.io/$(QUAY_REPO)/$(IMAGE_NAME):$(IMAGE_TAG)
 GIT_REPO_URL=https://github.com/$(GIT_USER)/${REPO}
 JH_ODH_REPO_URL=https://github.com/$(GIT_USER)/${JH_ODH_REPO}
 
+ADMIN_NAME ?= odhadmin
+ADMIN_PASS ?= odhadmin
+ADMIN_HTPASSWD_SECRET ?= htpasswd-$(ADMIN_NAME)-secret
+ADMIN_HTPASSWD_FILE="./$(ADMIN_NAME).htpasswd"
+ADMIN_GROUP ?= odh-admins
+
+USER_NAME ?= odhuser
+USER_PASS ?= odhuser
+USER_HTPASSWD_SECRET ?= "htpasswd-$(USER_NAME)-secret"
+USER_HTPASSWD_FILE="./$(USER_NAME).htpasswd"
+USER_GROUP ?= odh-users
 
 all: namespace prep-dc local
 legacy: namespace prep-is local-legacy
@@ -105,3 +116,10 @@ route:
 
 clean:
 	oc delete project ${NAMESPACE}
+
+users:
+	@echo Creating users
+	@./openshift/create-users.sh \
+		-an $(ADMIN_NAME) -ap $(ADMIN_PASS) -ag $(ADMIN_GROUP) \
+		-un $(USER_NAME) -up $(USER_PASS) -ug $(USER_GROUP) \
+		-n $(NAMESPACE)

--- a/README.md
+++ b/README.md
@@ -4,6 +4,27 @@ This repo serves as a build wrapper for https://github.com/opendatahub-io/jupyte
 
 Both methods described below require every change to be pushed to your fork of jupyterhub-singleuser-profiles repo so that the [Dockerfile](/Dockerfile) can install from there. 
 
+## Configuration
+
+You can set these options in a local `.env.local` file:
+```
+QUAY_REPO=<your quay repo user name> # a system user is used by default
+GIT_USER=<your github user name> # a system user is used by default
+NAMESPACE=<applications namespace>  # default 'odh-ods-operator', set to 'odh-redhat-ods-applications' for downstream
+OPERATOR_NAME=<operator name> # default 'odh-operator', set to 'rhods-operator' for downstream
+OPERATOR_NAMESPACE=<operator name> # default 'odh-ods-operator', set to 'redhat-ods-operator' for downstream
+GIT_REF=<your github jsp branch to deploy>
+REMOTE_CMD=<podman | docker> # default 'podman'
+
+ADMIN_NAME ?= <admin username> # default 'odhadmin'
+ADMIN_PASS ?= <admin password> # default 'odhadmin' 
+ADMIN_GROUP ?= <admin-group> # default 'odh-admins', set to 'rhods-admins' for downstream
+
+USER_NAME ?= <user username> # default 'odhuser'
+USER_PASS ?= <user password> # default 'odhuser' 
+USER_GROUP ?= <user-group> # default 'odh-users', set to 'rhods-users' for downstream
+```
+
 ## Build locally
 
 ```
@@ -13,10 +34,11 @@ make
 The above command will
 
 1. Update the ImageStream in the cluster to point to your custom image on Quay.io
-2. Build using podman
+2. Build using podman or docker
 3. Tag and push the result to `quay.io/$USER/jupyterhub-img:test-jsp`
 4. Import the new image in your cluster
-5. Start a rollout of new version
+5. Scale down the operator, if necessary (preventing auto re-deploy)
+6. Start a rollout of new version
 
 
 ## Build remotely
@@ -29,7 +51,8 @@ The above command will
 
 1. Create a new BuildConfig for your build
 2. Kick off the build with log watch
-3. Start a rollout of new version
+3. Scale down the operator, if necessary (preventing auto re-deploy)
+4. Start a rollout of new version
 
 ## Build with specific jupyterhub-odh branch
 
@@ -48,10 +71,21 @@ The above command will
 * `JH_ODH_REPO` - Name of the jupyterhub-odh repo
 * `JH_ODH_REF` - Git branch of jupyterhub-odh
 
-## Configuration
+## Create Users
 
-You can change these options
+```
+make users
+```
 
-* `USER` - a system user is used by default, will be used for GH user and Quay.io user
-* `NAMESPACE` - the OpenShift namespace where ODH is deployed
-* `GIT_REF` - Git reference where your code lives (only needed for remote builds)
+The above command will
+
+1. Create the cluster OAuth if necessary
+2. Create a `ADMIN_NAME` user with `ADMIN_PASS` password
+3. Add `ADMIN_NAME` to the OAuth
+4. Add `ADMIN_NAME` to the `ADMIN_GROUP`
+5. Create a cluster admin role binding for `ADMIN_NAME`
+7. Create a `USER_NAME` user with `USER_PASS` password
+8. Add `USER_NAME` to the OAuth
+9. Add `USER_NAME` to the `USER_GROUP`
+10. Create a namespaced basic user role binding for the `USER_NAME`
+11. Grant view privilege for `USER_NAME` for project `NAMESPACE`

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ NAMESPACE=<applications namespace>  # default 'odh-ods-operator', set to 'odh-re
 OPERATOR_NAME=<operator name> # default 'odh-operator', set to 'rhods-operator' for downstream
 OPERATOR_NAMESPACE=<operator name> # default 'odh-ods-operator', set to 'redhat-ods-operator' for downstream
 GIT_REF=<your github jsp branch to deploy>
-REMOTE_CMD=<podman | docker> # default 'podman'
+LOCAL_CMD=<podman | docker> # default 'podman'
 
 ADMIN_NAME ?= <admin username> # default 'odhadmin'
 ADMIN_PASS ?= <admin password> # default 'odhadmin' 

--- a/clean.sh
+++ b/clean.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+set -x
+rm -rf jupyterhub-singleuser-profiles

--- a/clean.sh
+++ b/clean.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-set -x
-rm -rf jupyterhub-singleuser-profiles

--- a/openshift/build.yaml
+++ b/openshift/build.yaml
@@ -29,7 +29,7 @@ spec:
   source:
     type: Git
     git:
-      uri: 'https://github.com/vpavlin/jsp-wrapper'
+      uri: 'https://github.com/jeff-phillips-18/jsp-wrapper'
       ref: main
   triggers:
   runPolicy: Serial

--- a/openshift/build.yaml
+++ b/openshift/build.yaml
@@ -21,7 +21,7 @@ spec:
     dockerStrategy:
       from:
         kind: DockerImage
-        name: 'quay.io/odh-jupyterhub/jupyterhub-img:v0.3.0'
+        name: 'quay.io/odh-jupyterhub/jupyterhub-img:v0.3.4'
       buildArgs:
       - {"name": "user", "value": "vpavlin"}
       - {"name": "branch", "value": "master"}

--- a/openshift/build.yaml
+++ b/openshift/build.yaml
@@ -29,7 +29,7 @@ spec:
   source:
     type: Git
     git:
-      uri: 'https://github.com/jeff-phillips-18/jsp-wrapper'
+      uri: 'https://github.com/vpavlin/jsp-wrapper'
       ref: main
   triggers:
   runPolicy: Serial

--- a/openshift/create-users.sh
+++ b/openshift/create-users.sh
@@ -1,0 +1,290 @@
+#!/usr/bin/env bash
+
+while [[ $# -gt 0 ]]; do
+  key="$1"
+
+  case $key in
+  -an | --admin-name)
+    ADMIN_NAME="$2"
+    shift # past argument
+    shift # past value
+    ;;
+  -ap | --admin-password)
+    ADMIN_PASS="$2"
+    shift # past argument
+    shift # past value
+    ;;
+  -ag | --admin-group)
+    ADMIN_GROUP="$2"
+    shift # past argument
+    shift # past value
+    ;;
+  -un | --user-name)
+    USER_NAME="$2"
+    shift # past argument
+    shift # past value
+    ;;
+  -up | --user-password)
+    USER_PASS="$2"
+    shift # past argument
+    shift # past value
+    ;;
+  -ug | --user-group)
+    USER_GROUP="$2"
+    shift # past argument
+    shift # past value
+    ;;
+  -n | --namespace)
+    NAMESPACE="$2"
+    shift # past argument
+    shift # past value
+    ;;
+  *) # unknown option
+    shift # past argument
+    ;;
+  esac
+done
+
+if [ -z "$ADMIN_NAME" ]; then
+  echo -an or -admin-name must be supplied
+  exit
+fi
+if [ -z "$ADMIN_PASS" ]; then
+  echo -ap or -admin-password must be supplied
+  exit
+fi
+if [ -z "$ADMIN_GROUP" ]; then
+  echo -ag or -admin-group must be supplied
+  exit
+fi
+if [ -z "$USER_NAME" ]; then
+  echo -un or -user-name must be supplied
+  exit
+fi
+if [ -z "$USER_PASS" ]; then
+  echo -up or -user-password must be supplied
+  exit
+fi
+if [ -z "USER_GROUP" ]; then
+  echo -ug or -user-group must be supplied
+  exit
+fi
+if [ -z "$NAMESPACE" ]; then
+  echo -n or -namespace must be supplied
+  exit
+fi
+
+TEMP_DIR="openshift/temp"
+mkdir -p ${TEMP_DIR}
+
+OC_USERS_LIST="$(oc get users)"
+
+ADMIN_HTPASSWD_FILE="${TEMP_DIR}/${ADMIN_NAME}.htpasswd"
+ADMIN_HTPASSWD_SECRET="htpasswd-${ADMIN_NAME}-secret"
+
+if echo "${OC_USERS_LIST}" | grep -q -w "${ADMIN_NAME}"; then
+  echo -e "\033[0;32m \xE2\x9C\x94 User ${ADMIN_NAME} already exists \033[0m"
+else
+  SECRET="$(oc get secret ${ADMIN_HTPASSWD_SECRET} -n openshift-config --ignore-not-found=true --no-headers | grep -w ${ADMIN_HTPASSWD_SECRET})"
+  if [ -z "${SECRET}" ]; then
+    echo Creating ${ADMIN_NAME} credentials
+    htpasswd -cb ${ADMIN_HTPASSWD_FILE} ${ADMIN_NAME} ${ADMIN_PASS}
+    oc create secret generic ${ADMIN_HTPASSWD_SECRET} --from-file=htpasswd=${ADMIN_HTPASSWD_FILE} -n openshift-config
+    rm ${ADMIN_HTPASSWD_FILE}
+  else
+    echo -e "\033[0;32m \xE2\x9C\x94 Credentials for ${ADMIN_NAME} already exists (not necessarily this password!) \033[0m"
+  fi
+fi
+
+USER_HTPASSWD_FILE="${TEMP_DIR}/${USER_NAME}.htpasswd"
+USER_HTPASSWD_SECRET="htpasswd-${USER_NAME}-secret"
+
+if echo "${OC_USERS_LIST}" | grep -q -w "${USER_NAME}"; then
+  echo -e "\033[0;32m \xE2\x9C\x94 User ${USER_NAME} already exists \033[0m"
+else
+  SECRET="$(oc get secret ${USER_HTPASSWD_SECRET} -n openshift-config --ignore-not-found=true --no-headers | grep -w ${USER_HTPASSWD_SECRET})"
+  if [ -z "${SECRET}" ]; then
+    echo Creating ${USER_NAME} credentials
+    htpasswd -cb ${USER_HTPASSWD_FILE} ${USER_NAME} ${USER_PASS}
+    oc create secret generic ${USER_HTPASSWD_SECRET} --from-file=htpasswd=${USER_HTPASSWD_FILE} -n openshift-config
+    rm ${USER_HTPASSWD_FILE}
+  else
+    echo -e "\033[0;32m \xE2\x9C\x94 Credentials for ${USER_NAME} already exists (not necessarily this password!) \033[0m"
+  fi
+fi
+
+OAUTHS="$(oc get oauth/cluster -o custom-columns=CONTAINER:.spec.identityProviders --no-headers)"
+OAUTH_FOUND=$(echo "${OAUTHS}" | grep -v "<none>")
+
+# Create the cluster OAUTH if necessary
+if [ -z "${OAUTH_FOUND}" ]; then
+  echo Creating OAuth...
+  oc apply -f - <<EOF
+apiVersion: config.openshift.io/v1
+kind: OAuth
+metadata:
+  name: cluster
+spec:
+  identityProviders:
+    - name: ${ADMIN_NAME}
+      mappingMethod: claim
+      challenge: true
+      login: true
+      type: HTPasswd
+      htpasswd:
+        fileData:
+          name: ${ADMIN_HTPASSWD_SECRET}
+    - name: ${USER_NAME}
+      mappingMethod: claim
+      challenge: true
+      login: true
+      type: HTPasswd
+      htpasswd:
+        fileData:
+          name: ${USER_HTPASSWD_SECRET}
+EOF
+else
+  OAUTH_NAMES="$(oc get oauth -o custom-columns=CONTAINER:.spec.identityProviders[\*].name --no-headers)"
+
+  ADMIN_FOUND=$(echo "${OAUTH_NAMES}" | grep -w ${ADMIN_NAME})
+  if [ -z "${ADMIN_FOUND}" ]; then
+    echo "adding ${ADMIN_NAME} to OAuth"
+    oc patch oauth cluster --type='json' --patch "
+    [
+      {
+        \"op\": \"add\",
+        \"path\": \"/spec/identityProviders/-\",
+        \"value\": {
+          \"name\": \"${ADMIN_NAME}\",
+          \"mappingMethod\": \"claim\",
+          \"challenge\": \"true\",
+          \"login\": \"true\",
+          \"type\": \"HTPasswd\",
+          \"htpasswd\":
+            {
+              \"fileData\": {
+                \"name\": \"${ADMIN_HTPASSWD_SECRET}\"
+              }
+            }
+        }
+      }
+    ]"
+  else
+    echo -e "\033[0;32m \xE2\x9C\x94 ${ADMIN_NAME} already in OAuth \033[0m"
+  fi
+
+  USER_FOUND=$(echo "${OAUTH_NAMES}" | grep -w ${USER_NAME})
+  if [ -z "${USER_FOUND}" ]; then
+  echo "adding ${USER_NAME} to OAuth"
+    oc patch oauth cluster --type='json' --patch "
+    [
+      {
+        \"op\": \"add\",
+        \"path\": \"/spec/identityProviders/-\",
+        \"value\": {
+          \"name\": \"${USER_NAME}\",
+          \"mappingMethod\": \"claim\",
+          \"challenge\": \"true\",
+          \"login\": \"true\",
+          \"type\": \"HTPasswd\",
+          \"htpasswd\":
+            {
+              \"fileData\": {
+                \"name\": \"${USER_HTPASSWD_SECRET}\"
+              }
+            }
+        }
+      }
+    ]"
+  else
+      echo -e "\033[0;32m \xE2\x9C\x94 ${USER_NAME} already in OAuth \033[0m"
+  fi
+fi
+
+ROLE_BINDINGS="$(oc get rolebindings -n ${NAMESPACE} -o custom-columns=CONTAINER:.metadata.name --no-headers)"
+
+ADMIN_RB_FOUND=$(echo "${ROLE_BINDINGS}" | grep -w "ods-admin")
+if [ -z "${ADMIN_RB_FOUND}" ]; then
+  echo Creating Admin Role binding...
+oc apply -f - <<EOF
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: ods-admin
+  namespace: ${NAMESPACE}
+subjects:
+  - kind: User
+    apiGroup: rbac.authorization.k8s.io
+    name: ${ADMIN_NAME}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: admin
+EOF
+else
+  RB_SUBJECTS="$(oc get rolebindings/ods-admin -n ${NAMESPACE}  -o custom-columns=CONTAINER:.subjects[\*].name --no-headers | sed -e "s/,/ /g")"
+  SUBJECT_FOUND=$(echo ${RB_SUBJECTS} | grep -w ${ADMIN_NAME})
+  if [ -z "${SUBJECT_FOUND}" ]; then
+    echo Patching RoleBinding with ${ADMIN_NAME}
+    oc patch rolebinding/ods-admin -n ${NAMESPACE} --type='json' --patch "
+    [
+      {
+        \"op\": \"add\",
+        \"path\": \"/subjects/-\",
+        \"value\": {
+          \"name\": \"${ADMIN_NAME}\",
+          \"kind\": \"User\",
+          \"apiGroup\": \"rbac.authorization.k8s.io\",
+        }
+      }
+    ]"
+  fi
+fi
+
+USER_RB_FOUND=$(echo "${ROLE_BINDINGS}" | grep -w "ods-user")
+if [ -z "${USER_RB_FOUND}" ]; then
+  echo Creating RoleBinding for ${USER_NAME}
+  oc apply -f - <<EOF
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: ods-user
+  namespace: ${NAMESPACE}
+subjects:
+  - kind: User
+    apiGroup: rbac.authorization.k8s.io
+    name: ${USER_NAME}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: basic-user
+EOF
+else
+  RB_SUBJECTS="$(oc get rolebindings/ods-user -n ${NAMESPACE}  -o custom-columns=CONTAINER:.subjects[\*].name --no-headers | sed -e "s/,/ /g")"
+  SUBJECT_FOUND=$(echo ${RB_SUBJECTS} | grep -w ${USER_NAME})
+  if [ -z "${SUBJECT_FOUND}" ]; then
+
+    echo Patching RoleBinding with ${USER_NAME}
+    oc patch rolebinding/ods-user -n ${NAMESPACE} --type='json' --patch "
+    [
+      {
+        \"op\": \"add\",
+        \"path\": \"/subjects/-\",
+        \"value\": {
+          \"name\": \"${USER_NAME}\",
+          \"kind\": \"User\",
+          \"apiGroup\": \"rbac.authorization.k8s.io\",
+        }
+      }
+    ]"
+  fi
+fi
+
+echo Adding users to groups
+oc patch group/${ADMIN_GROUP} --type='json' -p "[{\"op\": \"add\", \"path\":\"/users/-\", \"value\":\"${ADMIN_NAME}\"}]"
+oc patch group/${USER_GROUP} --type='json' -p "[{\"op\": \"add\", \"path\":\"/users/-\", \"value\":\"${USER_NAME}\"}]"
+
+oc adm policy add-role-to-user view ${USER_NAME} -n ${NAMESPACE}
+
+echo -e "\033[0;32m User ${ADMIN_NAME} created, login with: \033[0m oc login -u ${ADMIN_NAME} -p ${ADMIN_PASS}"
+echo -e "\033[0;32m User ${USER_NAME} created, login with: \033[0m oc login -u ${USER_NAME} -p ${USER_PASS}"

--- a/run.sh
+++ b/run.sh
@@ -10,12 +10,12 @@ npm install
 npm run build
 
 cd /opt/app-root/share/jupyterhub/static/
+rm -rf jsp-ui
 mkdir jsp-ui
+
 cp -a ${JSP_UI_SRC_PATH}/build/. /opt/app-root/share/jupyterhub/static/jsp-ui
 
 cd ${JSP_UI_SRC_PATH}/templates/
-yes | cp -rf spawn.html /opt/app-root/share/jupyterhub/templates/
-cd ${JSP_UI_SRC_PATH}/styles/
-yes | cp -rf style.less /opt/app-root/share/jupyterhub/static/less
+yes | cp -rf *.html /opt/app-root/share/jupyterhub/templates/
 
 fix-permissions /opt/app-root


### PR DESCRIPTION
This PR:

- Updates the run script to install all template files (necessary for admin and spawn-progress when it comes along)
- Add a clean script to remove the previous `jupyterhub-singleuser-profiles` to ensure nothing is left over
- Adds the ability to have an `.env.local` file to store variable settings for use in the makefile
- Add `make users` command to create an admin user and a non-privileged user

